### PR TITLE
Use better regex

### DIFF
--- a/src/main/java/com/haroldstudios/hexitextlib/HexResolver.java
+++ b/src/main/java/com/haroldstudios/hexitextlib/HexResolver.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class HexResolver {
 
-    private static final Pattern GRADIENT_PATTERN = Pattern.compile("<(gradient|g)(:#([a-fA-F0-9]){6})*>");
+    private static final Pattern GRADIENT_PATTERN = Pattern.compile("<(gradient|g)(:#([a-fA-F0-9]){6})+>");
     private static final Pattern HEX_PATTERN = Pattern.compile("<(#[a-fA-F0-9]{6})>");
 
 


### PR DESCRIPTION
`StringIndexOutOfBoundsException` occurs when passing a string that contains `<g>` or `<gradient>` to `parseHexString`. This will fix that issue.